### PR TITLE
BatteryState message without temperature

### DIFF
--- a/src/gazebo_ros_battery.cpp
+++ b/src/gazebo_ros_battery.cpp
@@ -242,7 +242,7 @@ void GazeboRosBattery::UpdateChild() {
 				battery_state_.current    = current_lpf_;
 				battery_state_.charge     = charge_;
 				battery_state_.percentage = (charge_/design_capacity_)*100;
-				battery_state_.temperature = temperature_;
+				// battery_state_.temperature = temperature_;
 				battery_state_publisher_.publish( battery_state_ );
 				std_msgs::Float32 battery_voltage_;
 				battery_voltage_.data = voltage_;


### PR DESCRIPTION
In melodic the battery state does not have the temperature member so catkin build fails with:

Errors     << gazebo_ros_battery:make .../logs/gazebo_ros_battery/build.make.002.log                       
.../gazebo_ros_battery/src/gazebo_ros_battery.cpp: In member function ‘virtual void gazebo::GazeboRosBattery::UpdateChild()’:
.../gazebo_ros_battery/src/gazebo_ros_battery.cpp:245:20: error: ‘sensor_msgs::BatteryState {aka struct sensor_msgs::BatteryState_<std::allocator<void> >}’ has no member named ‘temperature’
     battery_state_.temperature = temperature_;
                    ^~~~~~~~~~~
make[2]: *** [CMakeFiles/gazebo_ros_battery.dir/src/gazebo_ros_battery.cpp.o] Error 1
make[1]: *** [CMakeFiles/gazebo_ros_battery.dir/all] Error 2
make: *** [all] Error 2

So this commit also comments the line mentioned above so catkin build will be successful.